### PR TITLE
Make __init__.py work

### DIFF
--- a/nasdaq_stock/__init__.py
+++ b/nasdaq_stock/__init__.py
@@ -1,0 +1,1 @@
+from .nasdaq_stock import *


### PR DESCRIPTION
I found the reason it was raising the error. It was because when you make a module, the init file is what is imported. Adding this line will make the module work.